### PR TITLE
Fix WinError 5 Access Denied in Windows auto-updater

### DIFF
--- a/src/setiastro/saspro/gui/mixins/update_mixin.py
+++ b/src/setiastro/saspro/gui/mixins/update_mixin.py
@@ -326,9 +326,20 @@ class UpdateMixin:
 
         self.statusBar().showMessage(f"Update downloaded to {target_path}", 5000)
 
+        # Remove Zone.Identifier from downloaded zip (Windows "blocked" flag)
+        if sys.platform.startswith("win"):
+            try:
+                ads_path = str(target_path) + ":Zone.Identifier"
+                if os.path.exists(ads_path):
+                    os.remove(ads_path)
+            except Exception:
+                pass
+
         # Extract zip if needed
         if target_path.suffix.lower() == ".zip":
-            extract_dir = Path(tempfile.mkdtemp(prefix="saspro-update-"))
+            # Extract alongside the zip in Downloads (not temp, which has stricter ACLs)
+            extract_dir = target_path.parent / f"saspro-update-{target_path.stem}"
+            os.makedirs(extract_dir, exist_ok=True)
             try:
                 with zipfile.ZipFile(target_path, "r") as zf:
                     zf.extractall(extract_dir)
@@ -363,9 +374,26 @@ class UpdateMixin:
         if ok != QMessageBox.StandardButton.Yes:
             return
 
-        # Launch installer
+        # Launch installer with elevation (fixes WinError 5 on Windows)
         try:
-            subprocess.Popen([str(installer_path)], shell=False)
+            if sys.platform.startswith("win"):
+                # Remove Zone.Identifier ADS so Windows doesn't block the exe
+                try:
+                    ads_path = str(installer_path) + ":Zone.Identifier"
+                    if os.path.exists(ads_path):
+                        os.remove(ads_path)
+                except Exception:
+                    pass  # Not fatal if ADS removal fails
+
+                # Use ShellExecuteW with "runas" to request UAC elevation
+                import ctypes
+                ret = ctypes.windll.shell32.ShellExecuteW(
+                    None, "runas", str(installer_path), None, None, 1
+                )
+                if ret <= 32:
+                    raise OSError(f"ShellExecuteW failed with code {ret}")
+            else:
+                subprocess.Popen([str(installer_path)], shell=False)
         except Exception as e:
             QMessageBox.warning(self, self.tr("Update Failed"),
                                 self.tr("Could not start installer:\n{0}").format(e))


### PR DESCRIPTION
## Summary

Fixes #70 - The built-in auto-updater fails on Windows with [WinError 5] Access is denied every time.

### Root Cause
Three Windows security mechanisms block the current subprocess.Popen() approach:
1. **Zone.Identifier ADS** - Downloaded files carry an alternate data stream marking them as internet-sourced, causing Windows to block execution
2. **Temp directory ACLs** - %TEMP% has stricter security policies than user directories
3. **No UAC elevation** - Installers typically require admin privileges, but Popen doesn't trigger a UAC prompt

### Changes (1 file, 31 insertions, 3 deletions)
- **Remove Zone.Identifier ADS** from the downloaded ZIP before extraction, and from the extracted .exe before launch
- **Extract to Downloads folder** instead of %TEMP% (creates saspro-update-{name}/ subdirectory alongside the ZIP)
- **Use ShellExecuteW with runas** instead of subprocess.Popen to trigger a proper UAC elevation prompt

### Testing
| Scenario | Before | After |
|----------|--------|-------|
| Auto-updater download + launch | WinError 5 | UAC prompt appears |
| Non-admin user | Silent failure | UAC elevation requested |
| Non-Windows platforms | N/A | Unchanged (still uses subprocess.Popen) |

All changes are Windows-only (guarded by sys.platform.startswith('win')). No impact on macOS/Linux.