### PR TITLE
Python 3.12 compatibility issue: TypeError: object of type 'generator' has no len() in _as_header()

### DIFF
--- a/src/setiastro/saspro/plate_solver.py
+++ b/src/setiastro/saspro/plate_solver.py
@@ -463,7 +463,7 @@ def _as_header(hdr_like: Any) -> Header | None:
     # 1) flattened single string? try hard to parse
     if isinstance(hdr_like, str):
         h = _parse_header_blob_to_header(hdr_like)
-        return h if len(h.keys()) else None
+        return h if any(h.keys()) else None
 
     # 2) dict-ish
     try:


### PR DESCRIPTION
Plate Solving fails with the following error:
`TypeError: object of type 'generator' has no len()`

len() is called on h.keys() inside _as_header(). In Python 3.12, h.keys() is returning a generator-like object which len() does not support.

`Traceback (most recent call last):
  File ".../setiastro/saspro/plate_solver.py", line 2409, in _run
    ok, res = plate_solve_doc_inplace(self, doc, self.settings)
  File ".../setiastro/saspro/plate_solver.py", line 1822, in plate_solve_doc_inplace
    seed_h = _seed_header_from_meta(meta)
  File ".../setiastro/saspro/plate_solver.py", line 2019, in _seed_header_from_meta
    base = _as_header(base_src)
  File ".../setiastro/saspro/plate_solver.py", line 466, in _as_header
    return h if len(h.keys()) else None
TypeError: object of type 'generator' has no len()
`

This is solved by changing from len() to any() on line 466 of plate_solver.py. Platesolve now works.