### PR TITLE
Layers: crash hardening and much faster live compositing

### DIFF
--- a/src/setiastro/saspro/layers.py
+++ b/src/setiastro/saspro/layers.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 import numpy as np
 
+try:
+    import cv2  # optional; used for fast, low-memory resize/warp
+except Exception:  # pragma: no cover
+    cv2 = None
+
 BLEND_MODES = [
     "Normal",
     "Multiply",
@@ -137,12 +142,49 @@ def _apply_levels(img: np.ndarray, black_point: float, white_point: float, midto
 
     return np.clip(out, 0.0, 1.0)
 
+def _is_identity_transform(t: "LayerTransform | None") -> bool:
+    """True if the transform is (effectively) a no-op, so we can skip warping."""
+    if t is None:
+        return True
+    try:
+        return (abs(float(t.tx)) < 1e-6 and abs(float(t.ty)) < 1e-6 and
+                abs(float(t.rot_deg)) < 1e-6 and
+                abs(float(t.sx) - 1.0) < 1e-6 and abs(float(t.sy) - 1.0) < 1e-6)
+    except Exception:
+        return False
+
+
+def _scaled_transform(t: "LayerTransform", scale: float) -> "LayerTransform":
+    """Return a copy of t with translation/pivot scaled for a downsized canvas."""
+    if scale == 1.0:
+        return t
+    return LayerTransform(
+        tx=float(t.tx) * scale,
+        ty=float(t.ty) * scale,
+        rot_deg=float(t.rot_deg),
+        sx=float(t.sx),
+        sy=float(t.sy),
+        pivot_x=(None if t.pivot_x is None else float(t.pivot_x) * scale),
+        pivot_y=(None if t.pivot_y is None else float(t.pivot_y) * scale),
+    )
+
+
 def _resize_like(src: np.ndarray, tgt_shape_hw: tuple[int, int]) -> np.ndarray:
-    """Nearest resize without dependencies. src: (H,W[,C]), target: (H,W)."""
+    """Nearest resize. src: (H,W[,C]), target: (H,W). Uses OpenCV when available."""
     Ht, Wt = int(tgt_shape_hw[0]), int(tgt_shape_hw[1])
     Hs, Ws = src.shape[0], src.shape[1]
     if (Hs, Ws) == (Ht, Wt):
         return src
+    if cv2 is not None:
+        try:
+            out = cv2.resize(np.ascontiguousarray(src), (Wt, Ht),
+                             interpolation=cv2.INTER_NEAREST)
+            # cv2 drops a trailing singleton channel; restore if needed
+            if src.ndim == 3 and out.ndim == 2:
+                out = out[:, :, None]
+            return out
+        except Exception:
+            pass
     yi = (np.linspace(0, Hs - 1, Ht)).astype(np.int32)
     xi = (np.linspace(0, Ws - 1, Wt)).astype(np.int32)
     return src[yi][:, xi, ...] if src.ndim == 3 else src[yi][:, xi]
@@ -204,6 +246,23 @@ def _warp_affine_nearest(src: np.ndarray, out_hw: tuple[int, int], M_src_to_dst:
         C = None
     else:
         C = int(src.shape[2])
+
+    # Fast path: OpenCV warpAffine (C-optimized, low memory). M is src->dst;
+    # OpenCV inverts it internally when WARP_INVERSE_MAP is not set.
+    if cv2 is not None:
+        try:
+            M23 = np.asarray(M_src_to_dst, dtype=np.float32)[:2, :]
+            out = cv2.warpAffine(
+                np.ascontiguousarray(src), M23, (Wt, Ht),
+                flags=cv2.INTER_NEAREST,
+                borderMode=cv2.BORDER_CONSTANT,
+                borderValue=(float(fill),) * 4,
+            )
+            if C is not None and out.ndim == 2:
+                out = out[:, :, None]
+            return out.astype(src.dtype, copy=False)
+        except Exception:
+            pass
 
     # Compute inverse mapping
     try:
@@ -402,7 +461,8 @@ def _apply_mode(base: np.ndarray, src: np.ndarray, layer: ImageLayer) -> np.ndar
     return src
 
 
-def composite_stack(base_img: np.ndarray, layers: List[ImageLayer]) -> np.ndarray:
+def composite_stack(base_img: np.ndarray, layers: List[ImageLayer],
+                    max_dim: int | None = None) -> np.ndarray:
     """
     Composite a base image with a stack of ImageLayer objects.
 
@@ -412,11 +472,25 @@ def composite_stack(base_img: np.ndarray, layers: List[ImageLayer]) -> np.ndarra
     - Applies per-layer transform (translate/rotate/scale about pivot) in canvas space
       AFTER resizing the layer to the base canvas (H,W).
     - Applies the SAME transform to the layer's mask (if present) so alpha lines up.
+    - max_dim: if set and the base's longest side exceeds it, the whole composite
+      runs at a reduced resolution (for fast live previews). Layer translations are
+      scaled accordingly so geometry stays correct. Pass None (default) for full res.
     """
     if base_img is None:
         return None
 
-    out = _ensure_3c(_float01(base_img))
+    base_arr = np.asarray(base_img)
+    H0, W0 = int(base_arr.shape[0]), int(base_arr.shape[1])
+
+    # Optional preview downscale. Resize the RAW array first (cheap), then do the
+    # float/3-channel conversion on the small image — this keeps the whole
+    # composite at preview resolution instead of converting the full image first.
+    scale = 1.0
+    if max_dim and max(H0, W0) > int(max_dim):
+        scale = float(max_dim) / float(max(H0, W0))
+        base_arr = _resize_like(base_arr, (max(1, int(round(H0 * scale))),
+                                           max(1, int(round(W0 * scale)))))
+    out = _ensure_3c(_float01(base_arr))
     H, W = int(out.shape[0]), int(out.shape[1])
 
     # iterate bottom → top so the top-most layer renders last
@@ -432,9 +506,11 @@ def composite_stack(base_img: np.ndarray, layers: List[ImageLayer]) -> np.ndarra
         if src is None:
             continue
 
-        # ----- normalize to float01 + 3 channels + canvas size -----
-        s = _ensure_3c(_float01(src))
-        s = _resize_like(s, (H, W))
+        # ----- normalize to canvas size + float01 + 3 channels -----
+        # Resize the RAW source to the (possibly downscaled) canvas first, so the
+        # float/3-channel conversion runs at preview resolution, not full-res.
+        s = _resize_like(np.asarray(src), (H, W))
+        s = _ensure_3c(_float01(s))
 
         # ----- per-layer levels -----
         if bool(getattr(L, "levels_enabled", False)):
@@ -446,13 +522,17 @@ def composite_stack(base_img: np.ndarray, layers: List[ImageLayer]) -> np.ndarra
             )
 
         # ----- apply layer transform in canvas space -----
+        # Skip entirely for identity transforms — this is the common case and
+        # avoids an expensive full-canvas warp per layer per recomposite.
         t = getattr(L, "transform", None)
-        if t is not None:
+        t_eff = None
+        if not _is_identity_transform(t):
+            t_eff = _scaled_transform(t, scale)
             try:
-                s = _apply_transform_to_layer_image(s, t, H, W)
+                s = _apply_transform_to_layer_image(s, t_eff, H, W)
             except Exception:
                 # If transform fails for any reason, fall back to untransformed
-                pass
+                t_eff = None
 
         # ----- validate blend mode -----
         if getattr(L, "mode", None) not in BLEND_MODES:
@@ -475,10 +555,11 @@ def composite_stack(base_img: np.ndarray, layers: List[ImageLayer]) -> np.ndarra
             if m is not None:
                 m = _resize_like(m, (H, W))
 
-                # Apply SAME transform to mask so it stays registered with the layer pixels
-                if t is not None:
+                # Apply SAME (scaled) transform to mask so it stays registered with
+                # the layer pixels. Skip when the transform is identity.
+                if t_eff is not None:
                     try:
-                        m = _apply_transform_to_mask(m, t, H, W)
+                        m = _apply_transform_to_mask(m, t_eff, H, W)
                     except Exception:
                         pass
 

--- a/src/setiastro/saspro/layers_dock.py
+++ b/src/setiastro/saspro/layers_dock.py
@@ -451,7 +451,18 @@ class LayersDock(QDockWidget):
         self._apply_timer = QTimer(self)
         self._apply_timer.setSingleShot(True)
         self._apply_timer.timeout.connect(self._apply_list_to_view)
-        self._apply_debounce_ms = 100  # tweak 60–150ms as you like
+        # Full-resolution apply only fires after the user actually stops moving a
+        # control; long enough that brief mid-drag pauses don't trigger a costly
+        # full render (the live preview keeps things responsive during the drag).
+        self._apply_debounce_ms = 350
+
+        # Live-preview throttle: cap how often we recomposite/redraw while the
+        # user is actively dragging a slider (which fires valueChanged per tick).
+        self._preview_timer = QTimer(self)
+        self._preview_timer.setSingleShot(True)
+        self._preview_timer.timeout.connect(self._on_preview_throttle)
+        self._preview_interval_ms = 70
+        self._preview_pending = False
 
         # UI
         w = QWidget()
@@ -854,8 +865,8 @@ class LayersDock(QDockWidget):
             except Exception:
                 pass
 
-            # Live preview refresh
-            vw.apply_layer_stack(vw._layers)
+            # Live preview refresh — downscaled for snappy transform editing
+            vw.apply_layer_stack(vw._layers, preview=True)
 
         # Helper: cancel revert
         def _cancel_revert(orig_t: LayerTransform):
@@ -866,24 +877,58 @@ class LayersDock(QDockWidget):
                 roww.setTransformDirty(dirty)
             except Exception:
                 pass
-            vw.apply_layer_stack(vw._layers)
+            vw.apply_layer_stack(vw._layers, preview=True)
 
         dlg = _TransformDialog(
             self,
             t=lyr.transform,
             apply_cb=_apply_t,
             cancel_cb=_cancel_revert,
-            debounce_ms=200,   # tweak 150–300
+            debounce_ms=120,
         )
         dlg.exec()
+        # Final full-resolution composite once editing is done (OK or Cancel)
+        try:
+            vw.apply_layer_stack(vw._layers)
+        except Exception:
+            pass
 
 
     def _apply_list_to_view_debounced(self):
-        # restart the timer on every slider tick
+        # Sync the (cheap) control values every tick, but THROTTLE the actual
+        # recomposite/redraw so a fast slider drag doesn't trigger one per pixel.
+        vw = self.current_view()
+        if vw:
+            self._sync_layers_from_rows(vw)
+            self._request_preview(vw)
+        # …and (re)start the debounce timer for the trailing full-resolution apply.
         self._apply_timer.start(self._apply_debounce_ms)
         # Also refresh row heights so mode-dependent controls (like Sigmoid)
         # can expand/collapse the row visually.
         self._refresh_row_heights()
+
+    def _request_preview(self, vw):
+        """Throttle live previews: render immediately on the leading edge, then at
+        most once per interval while changes keep arriving (coalesced trailing)."""
+        if self._preview_timer.isActive():
+            self._preview_pending = True
+            return
+        self._do_preview(vw)
+        self._preview_timer.start(self._preview_interval_ms)
+
+    def _on_preview_throttle(self):
+        if self._preview_pending:
+            self._preview_pending = False
+            vw = self.current_view()
+            if vw:
+                self._do_preview(vw)
+            self._preview_timer.start(self._preview_interval_ms)
+
+    def _do_preview(self, vw):
+        try:
+            vw.apply_layer_stack(vw._layers, preview=True)
+        except Exception as ex:
+            print("[LayersDock] preview apply error:", ex)
 
     def _refresh_row_heights(self):
         """Update QListWidgetItem size hints to match current row widgets."""
@@ -932,44 +977,60 @@ class LayersDock(QDockWidget):
         self._rebuild_list()
         self._apply_list_to_view()
 
+    def _sync_layers_from_rows(self, vw) -> None:
+        """Copy UI control values into the layer objects.
+
+        Hardened against: None rows, the informational base row, and any drift
+        between the widget list and the layer list (delete/reorder/off-by-one).
+        """
+        layers = getattr(vw, "_layers", None) or []
+        n = min(len(layers), self.list.count())
+        for i in range(n):
+            it = self.list.item(i)
+            roww = self.list.itemWidget(it) if it is not None else None
+            if roww is None or getattr(roww, "_is_base", False):
+                continue
+            try:
+                p = roww.params()
+            except Exception:
+                continue
+            lyr = layers[i]
+            try:
+                lyr.visible = bool(p["visible"])
+                lyr.mode = p["mode"]
+                lyr.opacity = float(p["opacity"])
+                lyr.levels_enabled = bool(p.get("levels_enabled", False))
+                lyr.black_point = float(p.get("black_point", 0.0))
+                lyr.midtones = float(p.get("midtones", 0.5))
+                lyr.white_point = float(p.get("white_point", 1.0))
+
+                if "sigmoid_center" in p:
+                    lyr.sigmoid_center = float(p["sigmoid_center"])
+                if "sigmoid_strength" in p:
+                    lyr.sigmoid_strength = float(p["sigmoid_strength"])
+
+                mi = p.get("mask_index")
+                if mi is not None and mi > 0:
+                    lyr.mask_doc = roww.mask_combo.itemData(mi)
+                else:
+                    lyr.mask_doc = None
+
+                # Force luminance masks only
+                lyr.mask_use_luma = True
+                lyr.mask_invert = bool(p["mask_invert"])
+            except Exception as ex:
+                print("[LayersDock] sync row error:", ex)
+
     def _apply_list_to_view(self):
         vw = self.current_view()
         if not vw:
             return
-        n = self._layer_count()
-        rows = []
-        for i in range(n):
-            it = self.list.item(i)
-            rows.append(self.list.itemWidget(it))
-
-
-        for lyr, roww in zip(vw._layers, rows):
-            p = roww.params()
-            lyr.visible = p["visible"]
-            lyr.mode = p["mode"]
-            lyr.opacity = float(p["opacity"])
-            lyr.levels_enabled = bool(p.get("levels_enabled", False))
-            lyr.black_point = float(p.get("black_point", 0.0))
-            lyr.midtones = float(p.get("midtones", 0.5))
-            lyr.white_point = float(p.get("white_point", 1.0))
-
-            # Sigmoid parameters (if present)
-            if "sigmoid_center" in p:
-                lyr.sigmoid_center = float(p["sigmoid_center"])
-            if "sigmoid_strength" in p:
-                lyr.sigmoid_strength = float(p["sigmoid_strength"])
-            mi = p["mask_index"]
-            if mi is not None and mi > 0:
-                doc = roww.mask_combo.itemData(mi)
-                lyr.mask_doc = doc
-            else:
-                lyr.mask_doc = None
-
-            # Force luminance masks only
-            lyr.mask_use_luma = True
-            lyr.mask_invert = bool(p["mask_invert"])
-        vw._reinstall_layer_watchers()
-        vw.apply_layer_stack(vw._layers)
+        self._sync_layers_from_rows(vw)
+        try:
+            vw._reinstall_layer_watchers()
+            vw.apply_layer_stack(vw._layers)
+        except Exception as ex:
+            print("[LayersDock] apply_list_to_view error:", ex)
 
     def _clear_layers(self):
         vw = self.current_view()

--- a/src/setiastro/saspro/subwindow.py
+++ b/src/setiastro/saspro/subwindow.py
@@ -77,7 +77,18 @@ from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavToolbar
 from matplotlib.figure import Figure
 
 from setiastro.saspro.autostretch import autostretch, autostretch_with_lut, apply_autostretch_lut
-from .layers import BLEND_MODES, ImageLayer, composite_stack
+from .layers import BLEND_MODES, ImageLayer, composite_stack, _resize_like
+
+
+def _layer_profile_log(msg: str):
+    """Append a layer-compositing timing line to <temp>/sas_layers_profile.log."""
+    try:
+        import os, tempfile, datetime
+        p = os.path.join(tempfile.gettempdir(), "sas_layers_profile.log")
+        with open(p, "a", encoding="utf-8") as f:
+            f.write(datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3] + "  " + msg + "\n")
+    except Exception:
+        pass
 from setiastro.saspro.dnd_mime import (
     MIME_ASTROMETRY,
     MIME_CMD,
@@ -1386,22 +1397,197 @@ class ImageSubWindow(QWidget):
 
 
       
-    def apply_layer_stack(self, layers):
+    # Longest-side limit used while compositing a live preview. Full resolution
+    # is always used for merges / non-preview applies.
+    _LAYER_PREVIEW_MAX_DIM = 1100
+    # When True, per-update timing (composite / upscale / render) is appended to
+    # <temp>/sas_layers_profile.log. Set False to disable once diagnosed.
+    _LAYER_PROFILE = False
+
+    def apply_layer_stack(self, layers, *, preview: bool = False):
         """
         Rebuild the display override from base document + given layer stack.
         Does not mutate the underlying document.image.
+
+        preview=True composites at a reduced resolution for snappy live editing;
+        the result is upscaled back to full canvas size so view coordinates stay
+        valid. A trailing full-resolution apply produces the final quality.
         """
+        # Re-entrancy guard: watched-doc 'changed' signals fire during _render /
+        # apply_edit, which could recursively re-trigger compositing and freeze the
+        # UI. Drop overlapping calls; the latest layer state is recomposited by the
+        # trailing (debounced/full) apply.
+        if getattr(self, "_compositing", False):
+            return
+        self._compositing = True
+        import time as _time
+        _t0 = _time.perf_counter()
+        _t1 = _t2 = _t0
+        base = None
         try:
             base = self.document.image
             if layers:
-                comp = composite_stack(base, layers)
-                self._display_override = comp
+                max_dim = self._LAYER_PREVIEW_MAX_DIM if preview else None
+                comp = composite_stack(base, layers, max_dim=max_dim)
+                _t1 = _time.perf_counter()
+                if preview:
+                    # Keep the composite SMALL. The fast preview renderer does the
+                    # autostretch/8-bit conversion on the small image and upscales
+                    # only the final pixmap, so no 16MP work happens per frame.
+                    # Set the override BEFORE emitting so listeners (e.g. the separate
+                    # Layer Preview window) can REUSE this already-composited result
+                    # instead of compositing a second time.
+                    _t2 = _time.perf_counter()
+                    self._display_override = comp
+                    self._render_layer_preview(comp)
+                    self.layers_changed.emit()
+                else:
+                    if (comp is not None and base is not None
+                            and comp.shape[:2] != base.shape[:2]):
+                        comp = _resize_like(comp, base.shape[:2])
+                    _t2 = _time.perf_counter()
+                    self._display_override = comp
+                    self.layers_changed.emit()
+                    self._render(rebuild=True)
             else:
                 self._display_override = None
-            self.layers_changed.emit()
-            self._render(rebuild=True)
+                _t1 = _t2 = _time.perf_counter()
+                self.layers_changed.emit()
+                self._render(rebuild=True)
+            _t3 = _time.perf_counter()
+            if getattr(self, "_LAYER_PROFILE", False):
+                try:
+                    sh = None if base is None else tuple(int(x) for x in base.shape[:2])
+                    _layer_profile_log(
+                        f"{'preview' if preview else 'full   '}  "
+                        f"composite={(_t1-_t0)*1000:7.1f}ms  "
+                        f"upscale={(_t2-_t1)*1000:7.1f}ms  "
+                        f"render={(_t3-_t2)*1000:7.1f}ms  "
+                        f"total={(_t3-_t0)*1000:7.1f}ms  "
+                        f"layers={len(layers)} base={sh}")
+                except Exception:
+                    pass
         except Exception as e:
-            print("[ImageSubWindow] apply_layer_stack error:", e)      
+            print("[ImageSubWindow] apply_layer_stack error:", e)
+        finally:
+            self._compositing = False
+
+    def _render_layer_preview(self, comp_small):
+        """Fast live preview render.
+
+        Does autostretch + 8-bit conversion on the SMALL composite, builds a small
+        QImage, then upscales only the resulting QPixmap (fast Qt scaling) to the
+        full source size so the on-screen zoom (which is in source-pixel units via
+        self.scale) stays consistent with the full-resolution document. This keeps
+        all per-pixel work at preview resolution instead of 16MP per frame.
+        """
+        try:
+            from PyQt6 import sip as _sip
+            if _sip.isdeleted(self):
+                return
+            lbl = getattr(self, "label", None)
+            if lbl is None or _sip.isdeleted(lbl):
+                return
+        except Exception:
+            return
+
+        base = getattr(self.document, "image", None)
+        if base is None or comp_small is None:
+            self._render(rebuild=True)
+            return
+
+        full_h, full_w = int(base.shape[0]), int(base.shape[1])
+        arr = np.asarray(comp_small)
+        if arr.ndim == 3 and arr.shape[2] == 1:
+            arr = arr[..., 0]
+        is_mono = (arr.ndim == 2)
+
+        import time as _pt
+        _ta = _pt.perf_counter()
+
+        # ---- autostretch on the small array, reusing the cached LUT if present ----
+        if self.autostretch_enabled:
+            arr_f = arr.astype(np.float32, copy=False)
+            try:
+                mx = float(arr_f.max()) if arr_f.size else 1.0
+            except Exception:
+                mx = 1.0
+            if mx > 5.0:
+                arr_f = arr_f / mx
+            lut = getattr(self, "_autostretch_lut_cache", None)
+            try:
+                if lut is not None:
+                    vis = apply_autostretch_lut(
+                        arr_f, lut,
+                        linked=(not is_mono and self._autostretch_linked),
+                    )
+                else:
+                    vis, lut2 = autostretch_with_lut(
+                        arr_f,
+                        target_median=self.autostretch_target,
+                        sigma=self.autostretch_sigma,
+                        linked=(not is_mono and self._autostretch_linked),
+                        use_24bit=None,
+                        no_black_clip=bool(getattr(self, "_no_black_clip", False)),
+                    )
+                    self._autostretch_lut_cache = lut2
+            except Exception:
+                vis = np.clip(arr_f, 0.0, 1.0)
+        else:
+            vis = arr
+
+        # ---- to uint8 RGB (still at preview resolution) ----
+        if vis.dtype == np.uint8:
+            buf8 = vis
+        else:
+            buf8 = (np.clip(vis.astype(np.float32, copy=False), 0.0, 1.0) * 255.0).astype(np.uint8)
+        if buf8.ndim == 2:
+            buf8 = np.stack([buf8] * 3, axis=-1)
+        elif buf8.ndim == 3 and buf8.shape[2] == 1:
+            buf8 = np.repeat(buf8, 3, axis=2)
+        elif buf8.ndim == 3 and buf8.shape[2] > 3:
+            buf8 = buf8[..., :3]
+        buf8 = np.ascontiguousarray(buf8)
+
+        h, w, _c = buf8.shape
+        _tb = _pt.perf_counter()
+        try:
+            qimg = QImage(buf8.tobytes(), w, h, 3 * w, QImage.Format.Format_RGB888)
+            pm_small = QPixmap.fromImage(qimg)
+            _tc = _pt.perf_counter()
+            # Scale straight from the small preview to the on-screen display size
+            # (full_size * current zoom) in ONE step — never materialize a 16MP
+            # intermediate pixmap, which is what made this path slow.
+            scale = float(getattr(self, "scale", 1.0) or 1.0)
+            sw = max(1, int(full_w * scale))
+            sh = max(1, int(full_h * scale))
+            pm_disp = pm_small.scaled(
+                sw, sh,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.FastTransformation,
+            )
+        except Exception:
+            self._render(rebuild=True)
+            return
+
+        # Keep the small pixmap as the source; the trailing full-resolution apply
+        # restores the true full-res _pm_src once dragging stops.
+        self._qimg_src = None
+        self._pm_src = pm_small
+        self._pm_src_wcs = None
+        self._buf8 = None
+        self.label.setPixmap(pm_disp)
+        self.label.resize(pm_disp.size())
+        if getattr(self, "_LAYER_PROFILE", False):
+            try:
+                _td = _pt.perf_counter()
+                _layer_profile_log(
+                    f"  prev-detail  stretch+8bit={(_tb-_ta)*1000:6.1f}ms  "
+                    f"toqimg={(_tc-_tb)*1000:6.1f}ms  "
+                    f"scale+paint={(_td-_tc)*1000:6.1f}ms  "
+                    f"small=({w}x{h}) disp=({sw}x{sh}) zoom={scale:.3f}")
+            except Exception:
+                pass
 
     def keyPressEvent(self, ev):
         if ev.key() == Qt.Key.Key_Space:


### PR DESCRIPTION
Layers panel: crash hardening and much faster live compositing

Summary

Hardens the Layers panel against the crashes it was prone to, and makes live editing on
large images dramatically faster by keeping per-frame work at preview resolution instead of
recompositing and re-rendering the full image on every change.

Motivation

On large images (e.g. 16 MP) the Layers panel was sluggish and crash-prone. Profiling a
single opacity-slider drag showed the full-resolution composite and render running on every
change, plus repeated full-resolution renders firing mid-drag, and several latent crash paths
(recursive recompositing, fragile row/layer syncing).

Changes

layers.py (compositing engine)


Skip identity transforms — previously every layer was run through a full-canvas affine warp
even with no transform (layers get a default identity transform), allocating large
temporaries per layer per recomposite. This was the main source of lag and OOM crashes.
Use OpenCV for resize/warp with a NumPy fallback (faster, far lower memory).
New max_dim preview-downscale parameter; the raw arrays are resized before the
float/RGB conversion so a preview genuinely runs at reduced resolution rather than
converting the full image first.


subwindow.py


Re-entrancy guard on apply_layer_stack — watched-document changed signals fired during
render/edit could recursively re-trigger compositing (freeze/crash). Overlapping calls are
now dropped; the trailing apply recomposites the latest state.
New preview=True fast path (_render_layer_preview): does autostretch + 8-bit conversion

QImage build on the small composite, then upscales only the final QPixmap so on-screen
zoom (which is in source-pixel units) stays consistent — avoiding the full-resolution
autostretch and pixmap rebuild on every frame. Reuses the cached autostretch LUT.



Avoids double-compositing for listeners by reusing the already-computed result.


layers_dock.py


Hardened the row→layer sync (_sync_layers_from_rows) against None widgets, the
informational base row, and any drift between the widget list and the layer list
(delete/reorder/off-by-one) — previously this could throw and corrupt state.
Throttle live previews (leading-edge + coalesced trailing) so a fast slider drag doesn't
recomposite per pixel, and lengthen the full-resolution debounce so the expensive full
render only runs after the user stops.


Behavior notes / trade-offs


During an active drag the in-view preview renders at reduced resolution; full resolution is
produced once editing settles (~350 ms after the last change).


Testing


Functional tests of composite_stack: blend + opacity math, transform/translate geometry,
identity-skip correctness, preview-downscale geometry, and OpenCV-vs-NumPy warp parity
(exact match).
py_compile on all changed modules.
