### PR TITLE
Fixed "In-process import failed (ValueError: module functions cannot set METH_CLASS or METH_STATIC)..." on ROCm/Linux

### DIFF
--- a/src/setiastro/saspro/runtime_torch.py
+++ b/src/setiastro/saspro/runtime_torch.py
@@ -609,16 +609,34 @@ def _purge_bad_torch_from_sysmodules(status_cb=print) -> None:
                 getattr(mod, "__version__", "") == "0.0.0+unavailable"
             )
 
-            if is_stub or (tf and ("site-packages" not in tf) and ("dist-packages" not in tf)):
+            is_shadow = bool(
+                tf and
+                ("site-packages" not in tf) and
+                ("dist-packages" not in tf)
+            )
+
+            # A successfully imported torch always registers torch._C.  If the
+            # parent package is still cached but the extension is missing, the
+            # module graph is already partial and must be discarded as a unit.
+            # Re-importing just torch._C is unsafe: CPython extension modules
+            # are not generally re-initializable, and doing so has caused both
+            # "module functions cannot set METH_CLASS or METH_STATIC" and
+            # native crashes in the ROCm/CUDA loaders.
+            is_partial = (
+                "torch._C" not in sys.modules and
+                getattr(mod, "_C", None) is not None
+            )
+
+            if is_stub or is_shadow or is_partial:
                 for k in list(sys.modules.keys()):
                     if k == "torch" or k.startswith("torch."):
                         sys.modules.pop(k, None)
                 if is_stub:
                     status_cb("[RT] Purged torch stub from sys.modules before real import")
+                elif is_partial:
+                    status_cb("[RT] Purged partial torch import before retry")
                 else:
                     status_cb(f"[RT] Purged shadowed torch import: {tf}")
-
-        sys.modules.pop("torch._C", None)
         importlib.invalidate_caches()
     except Exception:
         pass

--- a/tests/test_runtime_torch.py
+++ b/tests/test_runtime_torch.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from setiastro.saspro.runtime_torch import _purge_bad_torch_from_sysmodules
+
+
+def _clear_torch_modules(monkeypatch) -> None:
+    for name in list(sys.modules):
+        if name == "torch" or name.startswith("torch."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_purge_keeps_complete_site_packages_torch(monkeypatch) -> None:
+    _clear_torch_modules(monkeypatch)
+    torch = ModuleType("torch")
+    torch.__file__ = "/runtime/lib/python3.12/site-packages/torch/__init__.py"
+    torch_c = ModuleType("torch._C")
+    torch._C = torch_c
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch._C", torch_c)
+
+    _purge_bad_torch_from_sysmodules()
+
+    assert sys.modules["torch"] is torch
+    assert sys.modules["torch._C"] is torch_c
+
+
+def test_purge_removes_entire_partial_torch_graph(monkeypatch) -> None:
+    _clear_torch_modules(monkeypatch)
+    torch = ModuleType("torch")
+    torch.__file__ = "/runtime/lib/python3.12/site-packages/torch/__init__.py"
+    torch._C = ModuleType("torch._C")
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.nn", ModuleType("torch.nn"))
+
+    _purge_bad_torch_from_sysmodules()
+
+    assert not any(
+        name == "torch" or name.startswith("torch.") for name in sys.modules
+    )
+
+
+def test_purge_removes_entire_shadow_torch_graph(monkeypatch) -> None:
+    _clear_torch_modules(monkeypatch)
+    torch = ModuleType("torch")
+    torch.__file__ = "/worktree/torch/__init__.py"
+    torch_c = ModuleType("torch._C")
+    torch._C = torch_c
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch._C", torch_c)
+
+    _purge_bad_torch_from_sysmodules()
+
+    assert not any(
+        name == "torch" or name.startswith("torch.") for name in sys.modules
+    )


### PR DESCRIPTION
As discussed on Discord, I had a different error than others in the AMD GPU issues thread (https://discord.com/channels/1257377319765413961/1524949056571576500)

The error is: 
<img width="1166" height="580" alt="image" src="https://github.com/user-attachments/assets/359c67a2-86be-4b76-bcf9-34031439003f" />

This happened with every CosmicClarity related tool, and after installing the torch runtimes in different ways, official and unofficial.

This fix provides a different means to import, where the cache is purged based on different conditions.
The system I had errors with is / tested this fix on:
- **OS**: NixOS 26.05 (Yarara) x86_64
- **Container (SetiAstro Runs in)**: `distrobox create -n setiastro -i rocm/dev-ubuntu-24.04 --home ~/.homes/setiastro`
- **CPU**: AMD Ryzen AI 9 HX 370 (24) @ 5.16 GHz
- **GPU**: AMD Radeon 890M Graphics [Integrated]
- **Memory**: 31.13 GiB RAM, 31.13 GiB VRAM

**Disclaimer**: The code is AI assisted. I reviewed the code manually, and to the best of my abilities there seems to be no change in behavior for other setups. Still, because I cannot test on other GPUs or Linux setups, I will make this PR draft until further notice.

Thanks and have a nice day!